### PR TITLE
feat: support set cost to 0 or negative

### DIFF
--- a/lib/resty/limit/count.lua
+++ b/lib/resty/limit/count.lua
@@ -49,7 +49,7 @@ end
 -- parameter "cost" is only supported on the new interface
 local function incoming_new(self, key, commit, cost)
     cost = cost or 1
-    assert(cost >= 1)
+    assert(cost >= 0)
 
     local dict = self.dict
     local limit = self.limit

--- a/lib/resty/limit/count.lua
+++ b/lib/resty/limit/count.lua
@@ -49,7 +49,6 @@ end
 -- parameter "cost" is only supported on the new interface
 local function incoming_new(self, key, commit, cost)
     cost = cost or 1
-    assert(cost >= 0)
 
     local dict = self.dict
     local limit = self.limit


### PR DESCRIPTION
Support setting cost to 0 for pre check quota.

`incoming(key, 0)`